### PR TITLE
added option to use the membername as password & a minor menu adjustment

### DIFF
--- a/Application.php
+++ b/Application.php
@@ -21,4 +21,18 @@ class _Application extends \IPS\Application
 	{
 		return 'plus-square';
 	}
+
+	public function acpMenu()
+	{
+		$menu = parent::acpMenu();
+
+		if ( !\IPS\Application::appIsEnabled( 'forums' ) )
+		{
+			unset ( $menu['forumgen'] );
+		}
+		
+		return $menu;
+	}
+
+
 }

--- a/modules/admin/tools/purge.php
+++ b/modules/admin/tools/purge.php
@@ -27,6 +27,14 @@ class _purge extends \IPS\Dispatcher\Controller
 		parent::execute();
 	}
 
+	protected function getContentTypes()
+	{
+		return array(
+				'topics' 	=> 'faker_form_topics',
+				'members'	=> 'faker_form_members'
+		);
+	}
+
 	/**
 	 * Display the content generation form
 	 *
@@ -37,10 +45,7 @@ class _purge extends \IPS\Dispatcher\Controller
 		$form = new \IPS\faker\Decorators\Form( 'form', 'faker_purge' );
 		$form->langPrefix = 'faker_form';
 		$form->add( new \IPS\Helpers\Form\CheckboxSet( 'content_types', 0, true, array(
-			'options' => array(
-				'topics' 	=> 'faker_form_topics',
-				'members'	=> 'faker_form_members'
-			)
+			'options' => $this->getContentTypes()
 		) ) );
 
 		if ( $values = $form->values() ) {

--- a/sources/Content/Member/Member.php
+++ b/sources/Content/Member/Member.php
@@ -43,13 +43,16 @@ class _Member extends \IPS\Member
 	{
 		$generator = new \IPS\faker\Content\Generator();
 
+
+
 		/* Create Member */
 		$member = new \IPS\Member;
 		$member->faker_fake			= 1;
 		$member->name				= $generator->userName();
+		$password =		isset ( $values['password'] ) ? $member->name : $generator->password();
 		$member->email				= $generator->email();
 		$member->members_pass_salt  = $member->generateSalt();
-		$member->members_pass_hash  = $member->encryptedPassword( $generator->password() );
+		$member->members_pass_hash  = $member->encryptedPassword( $password );
 		$member->allow_admin_mails  = 0;
 		$member->member_group_id	= $values['member_group'];
 		$member->members_bitoptions['view_sigs'] = TRUE;
@@ -93,6 +96,8 @@ class _Member extends \IPS\Member
 		$form->add( new \IPS\Helpers\Form\YesNo( 'profile_photo', true ) );
 		$form->add( new \IPS\Helpers\Form\Select( 'member_group', \IPS\Settings::i()->member_group, true,
 			array( 'options' => $groupOpts ) ) );
+
+		$form->add( new \IPS\Helpers\Form\YesNo( 'password' ) );
 		// TODO: Generate status posts
 
 		return $form;


### PR DESCRIPTION
This will add a option to the member generator to use the name as password. This will allow the admin to use the log in as the member without using the ACP => Login as ... feature.

The other change hides the forum related stuff if the forums app isn't enabled

purge controller modification to allow 3rd party apps to add own content types to the option